### PR TITLE
Change the exec calls to spawn

### DIFF
--- a/server/lib/build.js
+++ b/server/lib/build.js
@@ -196,16 +196,18 @@ function makeAppx(fileInfo) {
     })
 
     command.on('error', (err) => {
-      var errmsg;
-        var toolErrors = stdout.match(/error:.*/g);
-        if (toolErrors) {
-          errmsg = stdout.match(/error:.*/g).map(function (item) { return item.replace(/error:\s*/, ''); });
-        }
-        return deferred.reject(errmsg ? errmsg.join('\n') : 'MakeAppX failed.');
+      deferred.reject(err);
     })
 
     command.on("close", () => {
-      deferred.resolve(spawnPackage);
+      var errmsg;
+      var toolErrors = spawnPackage.stdout.match(/error:.*/g);
+      if (toolErrors) {
+        errmsg = spawnPackage.stdout.match(/error:.*/g).map(function (item) { return item.replace(/error:\s*/, ''); });
+        deferred.reject(errmsg);
+      } else {
+        deferred.resolve(spawnPackage);
+      }
     })
 
     return deferred.promise;

--- a/server/lib/build.js
+++ b/server/lib/build.js
@@ -139,17 +139,14 @@ function makePri(projectRoot, outputFolder) {
             command = spawn(cmdLine, {shell: true});
             
             command.stderr.on('data', (stderr) => {
-              console.log("stderr", stderr);
               spawnPackage.stderr = stderr;
             })
             
             command.stdout.on('data', (stdout) => {
-              console.log('stdout', stdout);
               spawnPackage.stdout = stdout;
             })
 
             command.on('error', (err) => {
-              console.log("err", err);
               return deferred.reject(err);
             })
 


### PR DESCRIPTION
This PR will change the exec calls in the build.js file to spawn calls to prevent buffer size issues.